### PR TITLE
Proxy protocol v1 support. Client/Server debug support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 package-lock.json
+/.idea/

--- a/README.md
+++ b/README.md
@@ -36,23 +36,24 @@ var session = smpp.connect({
 	url: 'smpp://example.com:2775',
 	auto_enquire_link_period: 10000,
 	debug: true
-});
-session.bind_transceiver({
-	system_id: 'YOUR_SYSTEM_ID',
-	password: 'YOUR_PASSWORD'
-}, function(pdu) {
-	if (pdu.command_status == 0) {
-		// Successfully bound
-		session.submit_sm({
-			destination_addr: 'DESTINATION NUMBER',
-			short_message: 'Hello!'
-		}, function(pdu) {
-			if (pdu.command_status == 0) {
-				// Message successfully sent
-				console.log(pdu.message_id);
-			}
-		});
-	}
+}, function() {
+	session.bind_transceiver({
+		system_id: 'YOUR_SYSTEM_ID',
+		password: 'YOUR_PASSWORD'
+	}, function(pdu) {
+		if (pdu.command_status === 0) {
+			// Successfully bound
+			session.submit_sm({
+				destination_addr: 'DESTINATION NUMBER',
+				short_message: 'Hello!'
+			}, function(pdu) {
+				if (pdu.command_status === 0) {
+					// Message successfully sent
+					console.log(pdu.message_id);
+				}
+			});
+		}
+	});
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Usage
 var smpp = require('smpp');
 var session = smpp.connect({
 	url: 'smpp://example.com:2775',
-	auto_enquire_link_period: 10000
+	auto_enquire_link_period: 10000,
+	debug: true
 });
 session.bind_transceiver({
 	system_id: 'YOUR_SYSTEM_ID',
@@ -59,7 +60,9 @@ session.bind_transceiver({
 
 ``` javascript
 var smpp = require('smpp');
-var server = smpp.createServer(function(session) {
+var server = smpp.createServer({
+	debug: true
+}, function(session) {
 	session.on('bind_transceiver', function(pdu) {
 		// we pause the session to prevent further incoming pdu events,
 		// untill we authorize the session with some async operation.
@@ -78,6 +81,19 @@ var server = smpp.createServer(function(session) {
 	});
 });
 server.listen(2775);
+```
+
+### Proxy protocol (v1) support
+Pass `enable_proxy_protocol_detection: true` as server option.
+
+### Debug
+To enable a simple debug of ingoing/outgoing messages pass `debug: true` as server/client option.
+
+Alternatively, you can listen for the `debug` even and write your own implementation:
+``` javascript
+session.on('debug', function(type, msg, payload) {
+	console.log({type: type, msg: msg, payload: payload});
+});
 ```
 
 Encodings

--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -4,20 +4,25 @@ var net = require('net'),
 	parse = require('url').parse,
 	defs = require('./defs'),
 	PDU = require('./pdu').PDU,
-	EventEmitter = require('events').EventEmitter;
+	EventEmitter = require('events').EventEmitter,
+	Buffer = require("safer-buffer").Buffer;
 
-function Session(options) {
+function Session(mode, options) {
 	EventEmitter.call(this);
 	this.options = options || {};
 	var self = this;
 	var transport = net;
+	this._extractPDUs = this._extractPDUs.bind(self);
 	this.sequence = 0;
 	this.paused = false;
 	this.remoteAddress = null;
+	this._proxyProtocolChecked = false;
 	this._busy = false;
 	this._callbacks = {};
 	this._interval = 0;
 	this._command_length = null;
+	this._mode = mode;
+	this._prevBytesRead = 0;
 	if (options.socket) {
 		this.socket = options.socket;
 	} else {
@@ -26,30 +31,32 @@ function Session(options) {
 		}
 		this.socket = transport.connect(this.options);
 		this.socket.on('connect', function() {
+			self.remoteAddress = self.socket.remoteAddress;
+			self.debug("socket.connect");
 			self.emit('connect');
 			if(self.options.auto_enquire_link_period) {
 				self._interval = setInterval(function() {
 					self.enquire_link();
 				}, self.options.auto_enquire_link_period);
 			}
-			if(this.remoteAddress === null) {
-				this.remoteAddress = this.socket.remoteAddress;
-			}
 		});
-		this.socket.on('secureConnect', function() {
+		this.socket.on('secureConnect',(function() {
+			self.remoteAddress = self.socket.remoteAddress;
+			self.debug("socket.connect");
 			self.emit('secureConnect');
-			if(this.remoteAddress === null) {
-				this.remoteAddress = this.socket.remoteAddress;
-			}
-		});
+		}).bind(this));
 	}
+	this.remoteAddress = this.socket.remoteAddress;
+	this.socket.on('open', function() {
+		self.debug("socket.open");
+	});
 	this.socket.on('readable', function() {
-		if(this.remoteAddress === null) {
-			this.remoteAddress = this.socket.remoteAddress;
-		}
-		this._extractPDUs.bind(this)
+		self.debug("socket.data.in", (self.socket.bytesRead - self._prevBytesRead) + " bytes");
+		self._prevBytesRead = self.socket.bytesRead;
+		self._extractPDUs();
 	});
 	this.socket.on('close', function() {
+		self.debug("socket.close");
 		self.emit('close');
 		if(self._interval) {
 			clearInterval(self._interval);
@@ -57,6 +64,7 @@ function Session(options) {
 		}
 	});
 	this.socket.on('error', function(e) {
+		self.debug("socket.error", e.message);
 		self.emit('error', e);
 		if(self._interval) {
 			clearInterval(self._interval);
@@ -66,6 +74,28 @@ function Session(options) {
 }
 
 util.inherits(Session, EventEmitter);
+
+Session.prototype.debug = function(type, msg, payload) {
+	if (type === undefined) type = null;
+	if (msg === undefined) msg = null;
+	if (this.options.debug) {
+		let coloredTypes = {
+			"reset": "\x1b[0m",
+			"client.connected": "\x1b[1m\x1b[34m",
+			"client.disconnected": "\x1b[1m\x1b[31m",
+			"pdu.command.in": "\x1b[36m",
+			"pdu.command.out": "\x1b[32m",
+		}
+		let now = new Date();
+		let logBuffer = now.toISOString() +
+			" - " + (coloredTypes.hasOwnProperty(type) ? coloredTypes[type] + type + coloredTypes.reset : type) +
+			" - " + msg +
+			" - " + (payload !== undefined ? JSON.stringify(payload) : "");
+		if (this.remoteAddress) logBuffer += " - [" + this.remoteAddress + "]"
+		console.log(logBuffer);
+	}
+	this.emit('debug', type, msg, payload);
+}
 
 Session.prototype.connect = function() {
 	this.sequence = 0;
@@ -83,10 +113,10 @@ Session.prototype._extractPDUs = function() {
 	var pdu;
 	while (!this.paused) {
 		try {
-			if(this.options.use_proxy_pass) {
-				this._handleProxyPass();
+			if(this._mode === "server" && this.options.enable_proxy_protocol_detection && !this._proxyProtocolChecked) {
+				this._handleProxyProtocolV1();
+				this._proxyProtocolChecked = true;
 			}
-
 			if(!this._command_length) {
 				this._command_length = PDU.commandLength(this.socket);
 				if(!this._command_length) {
@@ -96,6 +126,7 @@ Session.prototype._extractPDUs = function() {
 			if (!(pdu = PDU.fromStream(this.socket, this._command_length))) {
 				break;
 			}
+			this.debug("pdu.command.in", pdu.command);
 		} catch (e) {
 			this.emit('error', e);
 			return;
@@ -111,49 +142,67 @@ Session.prototype._extractPDUs = function() {
 	this._busy = false;
 };
 
-Session.prototype._handleProxyPass = function() {
-	var proxyBuffer = this.socket.read(6);
+Session.prototype._handleProxyProtocolV1 = function() {
+	let proxyBuffer = this.socket.read(6);
 	if (!proxyBuffer) {
 		return;
 	}
-
+	// Header specs: https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
 	if (proxyBuffer.toString() === 'PROXY ') {
-		var found = false;
-		var proxyPass = '';
-		var char = null;
-		var prevChar = null;
-		while (!found) {
-			char = this.socket.read(1).toString('ascii');
-			proxyPass += char;
+		let proxyProtocol = proxyBuffer;
+		let char = null;
+		let b = null;
+		let prevChar = null;
+		while (b = this.socket.read(1)) {
+			char = b.toString('ascii');
+			proxyProtocol += char;
 
-			if (char === "\n" && prevChar === "\r") {
-				found = true;
-			}
+			if (char === "\n" && prevChar === "\r") break;
 
-			if (proxyPass.length > 102) {
-				// Error!
+			if (proxyProtocol.length > 102) {
+				this.debug("proxy_protocol.error", "Proxy protocol header cannot exceed 102 bytes", proxyProtocol);
+				break;
 			}
 
 			prevChar = char;
 		}
+		this.debug("proxy_protocol.header.decoded", "Decoded", proxyProtocol.split("\r").join("").split("\n").join(""));
 
-		var proxyAddresses = '';
-		var extractRemoteAddress = false;
-
-		if (proxyPass.indexOf('IPV') === 0) { // 'PROXY IPV(4|6) .+\r\n'
-			proxyAddresses = proxyPass.substring(5, proxyPass.length - 2);
-			extractRemoteAddress = true;
-		} else if (proxyPass.indexOf('UNKNOWN') === 0) { // 'PROXY UNKNOWN( .+)?\r\n'
-			proxyAddresses = proxyPass.substring(8, proxyPass.length - 2);
+		let proxyProtocolAddressFound = null;
+		if (proxyProtocol.indexOf('PROXY IPV') === 0) { // 'PROXY IPV(4|6) .+\r\n'
+			let proxyProtocolParts = proxyProtocol.substring(10).split(' ');
+			if (proxyProtocolParts.length>1) proxyProtocolAddressFound = proxyProtocolParts[1];
 		}
 
-		if (extractRemoteAddress) {
-			this.remoteAddress = proxyAddresses.split(' ')[0].toLowerCase();
+		if (proxyProtocolAddressFound) {
+			this.remoteAddress = proxyProtocolAddressFound.toLowerCase();
+			this.debug("proxy_protocol.address.ok", "Found "+this.remoteAddress, this.remoteAddress);
+		} else {
+			this.debug("proxy_protocol.address.ko", "Not found");
 		}
+
 	} else {
+		this.debug("proxy_protocol.header.error","Header mismatch");
 		this.socket.unshift(proxyBuffer);
 	}
 }
+
+Session.prototype.sendFakeProxyProtocolHeader = function(headerString) {
+	this.socket.write(Buffer.from("PROXY "+headerString, 'ascii'), function() {});
+	return true;
+};
+
+Session.prototype.sendFakeProxyProtocolHeaderIPv4 = function(ipV4Src, ipV4Dest) {
+	if (ipV4Src === undefined) ipV4Src="1.2.3.4";
+	if (ipV4Dest === undefined) ipV4Dest="5.6.7.8";
+	return this.sendFakeProxyProtocolHeader("IPV4 "+ipV4Src+" "+ipV4Dest+" 2775 2775\r\n");
+};
+
+Session.prototype.sendFakeProxyProtocolHeaderIPv6 = function(ipV6Src, ipV6Dest) {
+	if (ipV6Src === undefined) ipV6Src="2001:db8:3333:4444:5555:6666:7777:8888";
+	if (ipV6Dest === undefined) ipV6Dest="2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF";
+	return this.sendFakeProxyProtocolHeader("IPV6 "+ipV6Src+" "+ipV6Dest+" 2775 2775\r\n");
+};
 
 Session.prototype.send = function(pdu, responseCallback, sendCallback) {
 	if (!this.socket.writable) {
@@ -176,7 +225,10 @@ Session.prototype.send = function(pdu, responseCallback, sendCallback) {
 	} else if (responseCallback && !sendCallback) {
 		sendCallback = responseCallback;
 	}
-	this.socket.write(pdu.toBuffer(), function() {
+	this.debug("pdu.command.out", pdu.command, pdu.length);
+	let buffer = pdu.toBuffer();
+	this.socket.write(buffer, function() {
+		this.debug("socket.data.out", buffer.length + " bytes");
 		this.emit('send', pdu);
 		if (sendCallback) {
 			sendCallback(pdu);
@@ -243,10 +295,12 @@ function Server(options, listener) {
 	var transport = this.tls ? tls : net;
 
 	transport.Server.call(this, options, function(socket) {
-		var session = new Session({socket: socket, use_proxy_pass: options.use_proxy_pass});
+		var session = new Session("server", {socket: socket, enable_proxy_protocol_detection: options.enable_proxy_protocol_detection, debug: options.debug});
+		session.debug("client.connected");
 		session.server = self;
 		self.sessions.push(session);
 		socket.on('close', function() {
+			session.debug("client.disconnected");
 			self.sessions.splice(self.sessions.indexOf(session), 1);
 		});
 		self.emit('session', session);
@@ -313,8 +367,9 @@ exports.connect = exports.createSession = function(url, listener) {
 		}
 	}
 	options.port = options.port || (options.tls ? 3550 : 2775);
+	options.debug = options.debug || false;
 
-	var session = new Session(options);
+	var session = new Session("client", options);
 	if (listener) {
 		session.on(options.tls ? 'secureConnect' : 'connect', listener);
 	}

--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -12,6 +12,7 @@ function Session(mode, options) {
 	this.options = options || {};
 	var self = this;
 	var transport = net;
+	var connectTimeout;
 	this._extractPDUs = this._extractPDUs.bind(self);
 	this.sequence = 0;
 	this.paused = false;
@@ -32,8 +33,18 @@ function Session(mode, options) {
 		if (options.tls) {
 			transport = tls;
 		}
+		connectTimeout = setTimeout(function() {
+			if (self.socket) {
+				var e = new Error("Timeout of " + options.connectTimeout + "ms while connecting to " +
+					self.options.host + ":" + self.options.port);
+				e.code = "ETIMEOUT";
+				e.timeout = options.connectTimeout;
+				self.socket.destroy(e);
+			}
+		}, options.connectTimeout);
 		this.socket = transport.connect(this.options);
 		this.socket.on('connect', (function() {
+			clearTimeout(connectTimeout);
 			self.remoteAddress = self.socket.remoteAddress;
 			self.debug("server.connected", "connected to server", {secure: options.tls});
 			self.emit('connect'); // @todo should emmit the session but it would break BC
@@ -60,6 +71,7 @@ function Session(mode, options) {
 		self._extractPDUs();
 	});
 	this.socket.on('close', function() {
+		clearTimeout(connectTimeout);
 		if (self._mode === "server") {
 			self.debug("client.disconnected", "client has disconnected");
 		} else {
@@ -72,12 +84,14 @@ function Session(mode, options) {
 		}
 	});
 	this.socket.on('error', function(e) {
-		self.debug("socket.error", e.message);
-		self.emit('error', e);
+		clearTimeout(connectTimeout);
+		self.debug("socket.error", e.message, e);
+		if (self.socket) self.socket.destroy();
 		if(self._interval) {
 			clearInterval(self._interval);
 			self._interval = 0;
 		}
+		self.emit('error', e); // Emitted errors will kill the program if they're not captured.
 	});
 }
 
@@ -96,6 +110,7 @@ Session.prototype.debug = function(type, msg, payload) {
 			"server.disconnected": "\x1b[1m\x1b[31m",
 			"pdu.command.in": "\x1b[36m",
 			"pdu.command.out": "\x1b[32m",
+			"socket.error": "\x1b[41m\x1b[30m"
 		}
 		var now = new Date();
 		var logBuffer = now.toISOString() +
@@ -385,6 +400,7 @@ exports.connect = exports.createSession = function(url, listener) {
 	}
 	options.port = options.port || (options.tls ? 3550 : 2775);
 	options.debug = options.debug || false;
+	options.connectTimeout = options.connectTimeout || 30000;
 
 	var session = new Session("client", options);
 	if (listener) {

--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -182,7 +182,7 @@ Session.prototype._handleProxyProtocolV1 = function() {
 		this.debug("proxy_protocol.header.decoded", "Decoded", proxyProtocol.split("\r").join("").split("\n").join(""));
 
 		var proxyProtocolAddressFound = null;
-		if (proxyProtocol.indexOf('PROXY IPV') === 0) { // 'PROXY IPV(4|6) .+\r\n'
+		if (proxyProtocol.indexOf('PROXY TCP') === 0) { // 'PROXY TCP(4|6) .+\r\n'
 			var proxyProtocolParts = proxyProtocol.substring(10).split(' ');
 			if (proxyProtocolParts.length>1) proxyProtocolAddressFound = proxyProtocolParts[1];
 		}
@@ -208,13 +208,13 @@ Session.prototype.sendFakeProxyProtocolHeader = function(headerString) {
 Session.prototype.sendFakeProxyProtocolHeaderIPv4 = function(ipV4Src, ipV4Dest) {
 	if (ipV4Src === undefined) ipV4Src="1.2.3.4";
 	if (ipV4Dest === undefined) ipV4Dest="5.6.7.8";
-	return this.sendFakeProxyProtocolHeader("IPV4 "+ipV4Src+" "+ipV4Dest+" 2775 2775\r\n");
+	return this.sendFakeProxyProtocolHeader("TCP4 "+ipV4Src+" "+ipV4Dest+" 2775 2775\r\n");
 };
 
 Session.prototype.sendFakeProxyProtocolHeaderIPv6 = function(ipV6Src, ipV6Dest) {
 	if (ipV6Src === undefined) ipV6Src="2001:db8:3333:4444:5555:6666:7777:8888";
 	if (ipV6Dest === undefined) ipV6Dest="2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF";
-	return this.sendFakeProxyProtocolHeader("IPV6 "+ipV6Src+" "+ipV6Dest+" 2775 2775\r\n");
+	return this.sendFakeProxyProtocolHeader("TCP6 "+ipV6Src+" "+ipV6Dest+" 2775 2775\r\n");
 };
 
 Session.prototype.sendFakeProxyProtocolHeaderUnknown= function() {

--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -242,7 +242,7 @@ Session.prototype.send = function(pdu, responseCallback, sendCallback) {
 	} else if (responseCallback && !sendCallback) {
 		sendCallback = responseCallback;
 	}
-	this.debug("pdu.command.out", pdu.command, pdu.length);
+	this.debug("pdu.command.out", pdu.command, pdu);
 	var buffer = pdu.toBuffer();
 	this.socket.write(buffer, function() {
 		this.debug("socket.data.out", null, {bytes: buffer.length});

--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -79,15 +79,15 @@ Session.prototype.debug = function(type, msg, payload) {
 	if (type === undefined) type = null;
 	if (msg === undefined) msg = null;
 	if (this.options.debug) {
-		let coloredTypes = {
+		var coloredTypes = {
 			"reset": "\x1b[0m",
 			"client.connected": "\x1b[1m\x1b[34m",
 			"client.disconnected": "\x1b[1m\x1b[31m",
 			"pdu.command.in": "\x1b[36m",
 			"pdu.command.out": "\x1b[32m",
 		}
-		let now = new Date();
-		let logBuffer = now.toISOString() +
+		var now = new Date();
+		var logBuffer = now.toISOString() +
 			" - " + (coloredTypes.hasOwnProperty(type) ? coloredTypes[type] + type + coloredTypes.reset : type) +
 			" - " + msg +
 			" - " + (payload !== undefined ? JSON.stringify(payload) : "");
@@ -143,16 +143,16 @@ Session.prototype._extractPDUs = function() {
 };
 
 Session.prototype._handleProxyProtocolV1 = function() {
-	let proxyBuffer = this.socket.read(6);
+	var proxyBuffer = this.socket.read(6);
 	if (!proxyBuffer) {
 		return;
 	}
 	// Header specs: https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
 	if (proxyBuffer.toString() === 'PROXY ') {
-		let proxyProtocol = proxyBuffer;
-		let char = null;
-		let b = null;
-		let prevChar = null;
+		var proxyProtocol = proxyBuffer;
+		var char = null;
+		var b = null;
+		var prevChar = null;
 		while (b = this.socket.read(1)) {
 			char = b.toString('ascii');
 			proxyProtocol += char;
@@ -168,9 +168,9 @@ Session.prototype._handleProxyProtocolV1 = function() {
 		}
 		this.debug("proxy_protocol.header.decoded", "Decoded", proxyProtocol.split("\r").join("").split("\n").join(""));
 
-		let proxyProtocolAddressFound = null;
+		var proxyProtocolAddressFound = null;
 		if (proxyProtocol.indexOf('PROXY IPV') === 0) { // 'PROXY IPV(4|6) .+\r\n'
-			let proxyProtocolParts = proxyProtocol.substring(10).split(' ');
+			var proxyProtocolParts = proxyProtocol.substring(10).split(' ');
 			if (proxyProtocolParts.length>1) proxyProtocolAddressFound = proxyProtocolParts[1];
 		}
 
@@ -226,7 +226,7 @@ Session.prototype.send = function(pdu, responseCallback, sendCallback) {
 		sendCallback = responseCallback;
 	}
 	this.debug("pdu.command.out", pdu.command, pdu.length);
-	let buffer = pdu.toBuffer();
+	var buffer = pdu.toBuffer();
 	this.socket.write(buffer, function() {
 		this.debug("socket.data.out", buffer.length + " bytes");
 		this.emit('send', pdu);

--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -22,28 +22,29 @@ function Session(mode, options) {
 	this._interval = 0;
 	this._command_length = null;
 	this._mode = mode;
+	this._id = Math.floor(Math.random() * (999999 - 100000)) + 100000; // random session id
 	this._prevBytesRead = 0;
 	if (options.socket) {
+		// server mode
 		this.socket = options.socket;
 	} else {
+		// client mode
 		if (options.tls) {
 			transport = tls;
 		}
 		this.socket = transport.connect(this.options);
-		this.socket.on('connect', function() {
+		this.socket.on('connect', (function() {
 			self.remoteAddress = self.socket.remoteAddress;
-			self.debug("socket.connect");
-			self.emit('connect');
+			self.debug("server.connected", "connected to server", {secure: options.tls});
+			self.emit('connect'); // @todo should emmit the session but it would break BC
 			if(self.options.auto_enquire_link_period) {
 				self._interval = setInterval(function() {
 					self.enquire_link();
 				}, self.options.auto_enquire_link_period);
 			}
-		});
+		}).bind(this));
 		this.socket.on('secureConnect',(function() {
-			self.remoteAddress = self.socket.remoteAddress;
-			self.debug("socket.connect");
-			self.emit('secureConnect');
+			self.emit('secureConnect'); // @todo should emmit the session, but it would break BC
 		}).bind(this));
 	}
 	this.remoteAddress = this.socket.remoteAddress;
@@ -51,12 +52,19 @@ function Session(mode, options) {
 		self.debug("socket.open");
 	});
 	this.socket.on('readable', function() {
-		self.debug("socket.data.in", (self.socket.bytesRead - self._prevBytesRead) + " bytes");
-		self._prevBytesRead = self.socket.bytesRead;
+		if ( (self.socket.bytesRead - self._prevBytesRead) > 0 ) {
+			// on disconnections the readable event receives 0 bytes, we do not want to debug that
+			self.debug("socket.data.in", null, {bytes: self.socket.bytesRead - self._prevBytesRead});
+			self._prevBytesRead = self.socket.bytesRead;
+		}
 		self._extractPDUs();
 	});
 	this.socket.on('close', function() {
-		self.debug("socket.close");
+		if (self._mode === "server") {
+			self.debug("client.disconnected", "client has disconnected");
+		} else {
+			self.debug("server.disconnected", "disconnected from server");
+		}
 		self.emit('close');
 		if(self._interval) {
 			clearInterval(self._interval);
@@ -81,18 +89,23 @@ Session.prototype.debug = function(type, msg, payload) {
 	if (this.options.debug) {
 		var coloredTypes = {
 			"reset": "\x1b[0m",
+			"dim": "\x1b[2m",
 			"client.connected": "\x1b[1m\x1b[34m",
 			"client.disconnected": "\x1b[1m\x1b[31m",
+			"server.connected": "\x1b[1m\x1b[34m",
+			"server.disconnected": "\x1b[1m\x1b[31m",
 			"pdu.command.in": "\x1b[36m",
 			"pdu.command.out": "\x1b[32m",
 		}
 		var now = new Date();
 		var logBuffer = now.toISOString() +
+			" - " + (this._mode === "server" ? "srv" : "cli") +
+			" - " + this._id +
 			" - " + (coloredTypes.hasOwnProperty(type) ? coloredTypes[type] + type + coloredTypes.reset : type) +
-			" - " + msg +
-			" - " + (payload !== undefined ? JSON.stringify(payload) : "");
+			" - " + (msg !== null ? msg : "" ) +
+			" - " + coloredTypes.dim + (payload !== undefined ? JSON.stringify(payload) : "") + coloredTypes.reset;
 		if (this.remoteAddress) logBuffer += " - [" + this.remoteAddress + "]"
-		console.log(logBuffer);
+		console.log( logBuffer );
 	}
 	this.emit('debug', type, msg, payload);
 }
@@ -126,7 +139,7 @@ Session.prototype._extractPDUs = function() {
 			if (!(pdu = PDU.fromStream(this.socket, this._command_length))) {
 				break;
 			}
-			this.debug("pdu.command.in", pdu.command);
+			this.debug("pdu.command.in", pdu.command, pdu);
 		} catch (e) {
 			this.emit('error', e);
 			return;
@@ -204,6 +217,10 @@ Session.prototype.sendFakeProxyProtocolHeaderIPv6 = function(ipV6Src, ipV6Dest) 
 	return this.sendFakeProxyProtocolHeader("IPV6 "+ipV6Src+" "+ipV6Dest+" 2775 2775\r\n");
 };
 
+Session.prototype.sendFakeProxyProtocolHeaderUnknown= function() {
+	return this.sendFakeProxyProtocolHeader("UNKNOWN\r\n");
+};
+
 Session.prototype.send = function(pdu, responseCallback, sendCallback) {
 	if (!this.socket.writable) {
 		return false;
@@ -228,7 +245,7 @@ Session.prototype.send = function(pdu, responseCallback, sendCallback) {
 	this.debug("pdu.command.out", pdu.command, pdu.length);
 	var buffer = pdu.toBuffer();
 	this.socket.write(buffer, function() {
-		this.debug("socket.data.out", buffer.length + " bytes");
+		this.debug("socket.data.out", null, {bytes: buffer.length});
 		this.emit('send', pdu);
 		if (sendCallback) {
 			sendCallback(pdu);
@@ -293,14 +310,14 @@ function Server(options, listener) {
 
 	this.tls = options.key && options.cert;
 	var transport = this.tls ? tls : net;
+	this.options = options;
 
 	transport.Server.call(this, options, function(socket) {
-		var session = new Session("server", {socket: socket, enable_proxy_protocol_detection: options.enable_proxy_protocol_detection, debug: options.debug});
-		session.debug("client.connected");
+		var session = new Session("server", {socket: socket, enable_proxy_protocol_detection: self.options.enable_proxy_protocol_detection, debug: self.options.debug});
+		session.debug("client.connected", "client has connected");
 		session.server = self;
 		self.sessions.push(session);
 		socket.on('close', function() {
-			session.debug("client.disconnected");
 			self.sessions.splice(self.sessions.indexOf(session), 1);
 		});
 		self.emit('session', session);
@@ -348,13 +365,13 @@ exports.connect = exports.createSession = function(url, listener) {
 	if (arguments.length > 1 && typeof listener != 'function') {
 		options = {
 			host: url,
-			port: listener
+			port: listener,
 		};
 		listener = arguments[3];
 	} else if (typeof url == 'string') {
 		options = parse(url);
 		options.host = options.slashes ? options.hostname : url;
-		options.tls = options.protocol == 'ssmpp:';
+		options.tls = options.protocol === 'ssmpp:';
 	} else if (typeof url == 'function') {
 		listener = url;
 	} else {
@@ -363,7 +380,7 @@ exports.connect = exports.createSession = function(url, listener) {
 			url = parse(options.url);
 			options.host = url.hostname;
 			options.port = url.port;
-			options.tls = url.protocol == 'ssmpp:';
+			options.tls = url.protocol === 'ssmpp:';
 		}
 	}
 	options.port = options.port || (options.tls ? 3550 : 2775);

--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -215,27 +215,6 @@ Session.prototype._handleProxyProtocolV1 = function() {
 	}
 }
 
-Session.prototype.sendFakeProxyProtocolHeader = function(headerString) {
-	this.socket.write(Buffer.from("PROXY "+headerString, 'ascii'), function() {});
-	return true;
-};
-
-Session.prototype.sendFakeProxyProtocolHeaderIPv4 = function(ipV4Src, ipV4Dest) {
-	if (ipV4Src === undefined) ipV4Src="1.2.3.4";
-	if (ipV4Dest === undefined) ipV4Dest="5.6.7.8";
-	return this.sendFakeProxyProtocolHeader("TCP4 "+ipV4Src+" "+ipV4Dest+" 2775 2775\r\n");
-};
-
-Session.prototype.sendFakeProxyProtocolHeaderIPv6 = function(ipV6Src, ipV6Dest) {
-	if (ipV6Src === undefined) ipV6Src="2001:db8:3333:4444:5555:6666:7777:8888";
-	if (ipV6Dest === undefined) ipV6Dest="2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF";
-	return this.sendFakeProxyProtocolHeader("TCP6 "+ipV6Src+" "+ipV6Dest+" 2775 2775\r\n");
-};
-
-Session.prototype.sendFakeProxyProtocolHeaderUnknown= function() {
-	return this.sendFakeProxyProtocolHeader("UNKNOWN\r\n");
-};
-
 Session.prototype.send = function(pdu, responseCallback, sendCallback) {
 	if (!this.socket.writable) {
 		return false;

--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -177,7 +177,7 @@ Session.prototype._handleProxyProtocolV1 = function() {
 	}
 	// Header specs: https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
 	if (proxyBuffer.toString() === 'PROXY ') {
-		var proxyProtocol = proxyBuffer;
+		var proxyProtocol = proxyBuffer.toString();
 		var char = null;
 		var b = null;
 		var prevChar = null;

--- a/test/proxy_protocol.js
+++ b/test/proxy_protocol.js
@@ -1,0 +1,96 @@
+var assert = require('assert'),
+    smpp = require('..');
+
+describe('ProxyProtocol', function() {
+	var server, port, debugBuffer = [];
+
+	before(function (done) {
+		server = smpp.createServer({
+			enable_proxy_protocol_detection: true,
+		}, function (session) {
+			debugBuffer = [];
+			session.on('pdu', function(pdu) {
+				session.send(pdu.response()); // Always reply
+			});
+			// We'll use the debug event to track what happened inside the server
+			session.on('debug', function(type, msg, payload) {
+				debugBuffer.push({type: type, msg: msg, payload: payload});
+			});
+		});
+		server.listen(0, done);
+		port = server.address().port;
+	});
+
+	after(function (done) {
+		server.sessions.forEach(function (session) {
+			session.close();
+		});
+		server.close(done);
+	});
+
+	it('should decode an IPv4 proxy protocol header and use it as remoteAddress', function (done) {
+		var session = smpp.connect({port: port}, function () {
+			var addr = "1.1.2.2";
+			session.sendFakeProxyProtocolHeaderIPv4(addr);
+			session.enquire_link(function (pdu) {
+				assert.equal(pdu.command, "enquire_link_resp");
+				assert.equal(server.sessions[0].remoteAddress, addr);
+				// Read the debug entries to find the proxy protocol header address ok notification
+				var debugEntry, i;
+				for (i = 0, debugEntry = null; i < debugBuffer.length && debugEntry === null; i++) if (debugBuffer[i].type === "proxy_protocol.address.ok") debugEntry = debugBuffer[i];
+				assert.notEqual(debugEntry, null, "proxy_protocol.address.ok entry not found in debug log ");
+				session.close(done);
+			});
+		});
+	});
+
+	it('should decode an IPv6 proxy protocol header and use it as remoteAddress', function (done) {
+		var session = smpp.connect({port: port}, function () {
+			var addr = "2001:db8:6666:7777:8888:3333:4444:5555";
+			session.sendFakeProxyProtocolHeaderIPv6(addr);
+			session.enquire_link(function (pdu) {
+				assert.equal(pdu.command, "enquire_link_resp");
+				assert.equal(server.sessions[0].remoteAddress, addr);
+				// Read the debug entries to find the proxy protocol header address ok notification
+				var debugEntry, i;
+				for (i = 0, debugEntry = null; i < debugBuffer.length && debugEntry === null; i++) if (debugBuffer[i].type === "proxy_protocol.address.ok") debugEntry = debugBuffer[i];
+				assert.notEqual(debugEntry, null, "proxy_protocol.address.ok entry not found in debug log");
+				session.close(done);
+			});
+		});
+	});
+
+	it('should decode an UNKNOWN proxy protocol header but ignore it', function (done) {
+		var session = smpp.connect({port: port}, function () {
+			session.sendFakeProxyProtocolHeaderUnknown();
+			session.enquire_link(function (pdu) {
+				assert.equal(pdu.command, "enquire_link_resp");
+				// Read the debug entries to find the proxy protocol header address ko notification
+				var debugEntry, i;
+				for (i = 0, debugEntry = null; i < debugBuffer.length && debugEntry === null; i++) if (debugBuffer[i].type === "proxy_protocol.header.decoded") debugEntry = debugBuffer[i];
+				assert.notEqual(debugEntry, null, "proxy_protocol.header.decoded entry not found in debug log");
+
+				for (i = 0, debugEntry = null; i < debugBuffer.length && debugEntry === null; i++) if (debugBuffer[i].type === "proxy_protocol.address.ko") debugEntry = debugBuffer[i];
+				assert.notEqual(debugEntry, null, "proxy_protocol.address.ko entry not found in debug log");
+
+				session.close(done);
+			});
+		});
+	});
+
+	it('should work even if no proxy protocol header is sent', function (done) {
+		var session = smpp.connect({port: port}, function () {
+			session.enquire_link(function (pdu) {
+				assert.equal(pdu.command, "enquire_link_resp");
+				// Read the debug entries to find the proxy protocol header error
+				var debugEntry, i;
+
+				for (i = 0, debugEntry = null; i < debugBuffer.length && debugEntry === null; i++) if (debugBuffer[i].type === "proxy_protocol.header.error") debugEntry = debugBuffer[i];
+				assert.notEqual(debugEntry, null, "proxy_protocol.header.error entry not found in debug log");
+
+				session.close(done);
+			});
+		});
+	});
+
+});

--- a/test/smpp.js
+++ b/test/smpp.js
@@ -329,4 +329,32 @@ describe('Client/Server simulations', function() {
 		});
 	});
 
+	it('should fail to connect with an invalid port and trigger a ECONNREFUSED error', function (done) {
+		var session = smpp.connect({port: 27750}, function () {});
+		session.on('error', function(e) {
+			// empty callback to catch emitted errors to prevent exit due unhandled errors
+			assert.equal(e.code, "ECONNREFUSED");
+			done();
+		});
+	});
+
+	it('should fail to connect with an invalid host and trigger a EAI_AGAIN error', function (done) {
+		var session = smpp.connect({url: 'smpp://unknownhost:2775'}, function () {});
+		session.on('error', function(e) {
+			// empty callback to catch emitted errors to prevent exit due unhandled errors
+			assert.equal(e.code, "EAI_AGAIN");
+			done();
+		});
+	});
+
+	it('should fail to connect with an invalid host and trigger a ETIMEOUT error', function (done) {
+		var session = smpp.connect({url: 'smpp://1.1.1.1:2775', connectTimeout: 25}, function () {});
+		session.on('error', function(e) {
+			// empty callback to catch emitted errors to prevent exit due unhandled errors
+			assert.equal(e.code, "ETIMEOUT");
+			done();
+		});
+	});
+
+
 });

--- a/test/smpp.js
+++ b/test/smpp.js
@@ -11,6 +11,22 @@ describe('Server', function() {
 
 	describe('#listen()', function() {
 		beforeEach(function (done) {
+			server.listen(6789, done);
+		});
+
+		afterEach(function (done) {
+			server.once('close', done);
+			server.close();
+		});
+
+		it('should bind to a custom port', function() {
+			assert.ok(server.address().port === 6789, 'Invalid custom port');
+		});
+
+	});
+
+	describe('#listenRandomPort()', function() {
+		beforeEach(function (done) {
 			server.listen(0, done);
 		});
 
@@ -30,22 +46,41 @@ describe('Server', function() {
 			var newPort = server.address().port;
 			assert.ok(newPort > 0, 'Invalid second random port');
 			assert.notEqual(newPort, port, 'Both random ports are equal!');
-		})
+		});
 	});
+
 });
 
 describe('Session', function() {
-	var server, port, secure = {};
+	var server, port, secure = {}, autoresponder = {};
+
 	var sessionHandler = function(session) {
-		session.on('pdu', function(pdu) {
+		session.on('enquire_link', function(pdu) {
 			session.send(pdu.response());
+		});
+		session.on('submit_sm', function(pdu) {
+			var response = pdu.response();
+			response.message_id = "123456789 sent to " + pdu.destination_addr; // Injected to verify the data received by the server
+			session.send(response);
+		});
+	};
+
+	var sessionHandlerAutoresponder = function(session) {
+		session.on('pdu', function(pdu) {
+			session.send(pdu.response()); // Always reply
 		});
 	};
 
 	before(function(done) {
-		server = smpp.createServer(sessionHandler);
+		server = smpp.createServer({}, sessionHandler);
 		server.listen(0, done);
 		port = server.address().port;
+	});
+
+	before(function(done) {
+		autoresponder.server = smpp.createServer({}, sessionHandlerAutoresponder);
+		autoresponder.server.listen(0, done);
+		autoresponder.port = autoresponder.server.address().port;
 	});
 
 	before(function(done) {
@@ -65,6 +100,13 @@ describe('Session', function() {
 	});
 
 	after(function(done) {
+		autoresponder.server.sessions.forEach(function(session) {
+			session.close();
+		});
+		autoresponder.server.close(done);
+	});
+
+	after(function(done) {
 		secure.server.sessions.forEach(function(session) {
 			session.close();
 		});
@@ -75,11 +117,11 @@ describe('Session', function() {
 		it('should use 2775 or 3550 as default port', function() {
 			var session = smpp.connect();
 			assert.equal(session.options.port, 2775);
-			var session = smpp.connect({tls: true});
+			session = smpp.connect({tls: true});
 			assert.equal(session.options.port, 3550);
-			var session = smpp.connect('smpp://localhost');
+			session = smpp.connect('smpp://localhost');
 			assert.equal(session.options.port, 2775);
-			var session = smpp.connect('ssmpp://localhost');
+			session = smpp.connect('ssmpp://localhost');
 			assert.equal(session.options.port, 3550);
 		});
 
@@ -87,7 +129,7 @@ describe('Session', function() {
 			var session = smpp.connect('127.0.0.1');
 			assert.equal(session.options.port, 2775);
 			assert.equal(session.options.host, '127.0.0.1');
-			var session = smpp.connect('127.0.0.1', 1234);
+			session = smpp.connect('127.0.0.1', 1234);
 			assert.equal(session.options.port, 1234);
 			assert.equal(session.options.host, '127.0.0.1');
 		});
@@ -96,20 +138,20 @@ describe('Session', function() {
 			var session = smpp.connect('smpp://127.0.0.1:1234');
 			assert.equal(session.options.port, 1234);
 			assert.equal(session.options.host, '127.0.0.1');
-			var session = smpp.connect('ssmpp://localhost');
+			session = smpp.connect('ssmpp://localhost');
 			assert(session.options.tls);
-			var session = smpp.connect({ url: 'ssmpp://127.0.0.1:1234'});
+			session = smpp.connect({ url: 'ssmpp://127.0.0.1:1234'});
 			assert(session.options.tls);
 			assert.equal(session.options.port, 1234);
 			assert.equal(session.options.host, '127.0.0.1');
 		});
 
 		it('should successfully establish a connection', function(done) {
-			var session = smpp.connect({ port: port }, done);
+			smpp.connect({ port: port }, done);
 		});
 
 		it('should successfully establish a secure connection', function(done) {
-			var session = smpp.connect({
+			smpp.connect({
 				port: secure.port,
 				tls: true,
 				rejectUnauthorized: false
@@ -118,15 +160,173 @@ describe('Session', function() {
 	});
 
 	describe('#send()', function() {
-		it('should successfully send a pdu and receive its response', function(done) {
-			var session = smpp.connect({ port: port });
-			var pdu = new smpp.PDU('enquire_link');
-			session.send(pdu, done.bind(this, null));
+		it('should successfully send a pdu', function(done) {
+			var session = smpp.connect({ port: port }, function() {
+				var pdu = new smpp.PDU('enquire_link');
+				session.send(pdu, done.bind(this, null));
+			});
 		});
 
 		it('should successfully send a pdu using shorthand methods', function(done) {
-			var session = smpp.connect({ port: port, auto_enquire_link_period:10000 });
-			session.enquire_link(done.bind(this, null));
+			var session = smpp.connect({ port: port, auto_enquire_link_period:10000 }, function() {
+				session.enquire_link(done.bind(this, null));
+			});
+		});
+
+		it('should successfully send a pdu on a secure connection', function(done) {
+			var session = smpp.connect({
+				port: secure.port,
+				tls: true,
+				rejectUnauthorized: false
+			}, function() {
+				session.enquire_link(done.bind(this, null));
+			});
+		});
+
+		it('should successfully send a pdu and receive its response', function(done) {
+			var session = smpp.connect({ port: port }, function() {
+				session.submit_sm({
+					destination_addr: "+01123456789",
+					short_message: "Hello!"
+				}, function(pdu) {
+					assert.equal(pdu.command, "submit_sm_resp");
+					assert.equal(pdu.command_status, smpp.ESME_ROK);
+					assert.equal(pdu.message_id, "123456789 sent to +01123456789");
+					done();
+				});
+			});
+		});
+
+		it('should successfully receive matching responses for any pdu sent with a generic autoreply server handler', function(done) {
+			var session = smpp.connect({ port: autoresponder.port}, function() {
+				session.bind_transceiver({}, function(pdu) {
+					assert.equal(pdu.command, "bind_transceiver_resp");
+					session.bind_receiver({}, function(pdu) {
+						assert.equal(pdu.command, "bind_receiver_resp");
+						session.bind_transmitter({}, function(pdu) {
+							assert.equal(pdu.command, "bind_transmitter_resp");
+							done();
+						});
+					});
+				});
+			});
+		});
+
+	});
+
+});
+
+describe('Client/Server simulations', function() {
+
+	var server, port, debugBuffer = [];
+
+	before(function (done) {
+		server = smpp.createServer({}, function (session) {
+			debugBuffer = [];
+			// We'll use the debug event to track what happened inside the server
+			session.on('debug', function(type, msg, payload) {
+				debugBuffer.push({type: type, msg: msg, payload: payload});
+			});
+			session.on('submit_sm', function (pdu) {
+				var response = pdu.response();
+				response.message_id = "123456789 sent to " + pdu.destination_addr; // Injected to verify the data received by the server
+				session.send(response);
+			});
+			session.on('bind_transceiver', function (pdu) {
+				// pause the session to prevent further incoming pdu events,
+				// untill we authorize the session with some async operation.
+				session.pause();
+				var checkAsyncUserPass = function (user, pwd, onComplete) {
+					setTimeout(function () {
+						if (user === "FAKE_USER" && pwd === "FAKE_PASSWORD") {
+							onComplete();
+						} else {
+							onComplete("invalid user and password combination");
+						}
+					}, 25); // Delayed processing simulation
+				};
+				checkAsyncUserPass(pdu.system_id, pdu.password, function (err) {
+					if (err) {
+						session.send(pdu.response({ command_status: smpp.ESME_RBINDFAIL}));
+						session.close();
+					} else {
+						session.send(pdu.response());
+						session.resume();
+					}
+				});
+			});
+		});
+		server.listen(0, done);
+		port = server.address().port;
+	});
+
+	after(function (done) {
+		server.sessions.forEach(function (session) {
+			session.close();
+		});
+		server.close(done);
+	});
+
+	it('should successfully bind a transceiver with a hardcoded user/password', function (done) {
+		var session = smpp.connect({port: port}, function () {
+			session.bind_transceiver({
+				system_id: 'FAKE_USER',
+				password: 'FAKE_PASSWORD'
+			}, function (pdu) {
+				assert.equal(pdu.command, "bind_transceiver_resp");
+				assert.equal(pdu.command_status, smpp.ESME_ROK);
+				// send fake message
+				session.submit_sm({
+					destination_addr: "+01123456789",
+					short_message: "Hello!"
+				}, function(pdu) {
+					assert.equal(pdu.command, "submit_sm_resp");
+					assert.equal(pdu.command_status, smpp.ESME_ROK);
+					assert.equal(pdu.message_id, "123456789 sent to +01123456789");
+					done();
+				});
+			});
 		});
 	});
+
+	it('should fail to bind a transceiver with a wrong hardcoded user/password', function (done) {
+		var session = smpp.connect({port: port}, function () {
+			session.bind_transceiver({
+				system_id: 'FAKE_USER_INVALID',
+				password: 'FAKE_PASSWORD_INVALID'
+			}, function (pdu) {
+				assert.equal(pdu.command, "bind_transceiver_resp");
+				assert.equal(pdu.command_status, smpp.ESME_RBINDFAIL);
+				done();
+			});
+		});
+	});
+
+	it('should successfully emit every expected debug log entry', function (done) {
+		var session = smpp.connect({port: port}, function () {
+			session.bind_transceiver({
+				system_id: 'FAKE_USER',
+				password: 'FAKE_PASSWORD'
+			}, function (pdu) {
+				assert.equal(pdu.command, "bind_transceiver_resp");
+				assert.equal(pdu.command_status, smpp.ESME_ROK);
+
+				// Read the server debug entries to find the relevant types that should have been emitted.
+				var debugEntry, i;
+
+				assert.notEqual(debugBuffer.length, 0, "Debug log is empty");
+
+				for (i = 0, debugEntry = null; i < debugBuffer.length && debugEntry === null; i++) if (debugBuffer[i].type === "pdu.command.in") debugEntry = debugBuffer[i];
+				assert.notEqual(debugEntry, null, "pdu.command.in entry not found in debug log");
+				assert.equal(debugEntry ? debugEntry.msg : null, "bind_transceiver", "bind_transceiver command not found in log");
+
+				for (i = 0, debugEntry = null; i < debugBuffer.length && debugEntry === null; i++) if (debugBuffer[i].type === "pdu.command.out") debugEntry = debugBuffer[i];
+				assert.notEqual(debugEntry, null, "pdu.command.out entry not found in debug log");
+				assert.equal(debugEntry ? debugEntry.msg : null, "bind_transceiver_resp", "bind_transceiver_resp command not found in log");
+
+				done();
+			});
+		});
+	});
+
 });

--- a/test/smpp.js
+++ b/test/smpp.js
@@ -338,11 +338,11 @@ describe('Client/Server simulations', function() {
 		});
 	});
 
-	it('should fail to connect with an invalid host and trigger a EAI_AGAIN error', function (done) {
+	it('should fail to connect with an invalid host and trigger a EAI_AGAIN or ENOTFOUND error', function (done) {
 		var session = smpp.connect({url: 'smpp://unknownhost:2775'}, function () {});
 		session.on('error', function(e) {
 			// empty callback to catch emitted errors to prevent exit due unhandled errors
-			assert.equal(e.code, "EAI_AGAIN");
+			assert.notEqual(-1, ["EAI_AGAIN","ENOTFOUND"].indexOf(e.code));
 			done();
 		});
 	});


### PR DESCRIPTION
Tests are not implemented yet. Proxy protocol has been tested by injecting the header from the client before sending any commands:

```
var smpp = require('./lib/smpp')
var session = smpp.connect({
	url: 'smpp://localhost:2775',
	auto_enquire_link_period: 10000,
	debug: true
});
session.sendFakeProxyProtocolHeaderIPv4(); // Inject fake header
session.bind_transceiver({
	system_id: 'YOUR_SYSTEM_ID',
	password: 'YOUR_PASSWORD'
}, function(pdu) {
	if (pdu.command_status == 0) {
		// Successfully bound
		session.submit_sm({
			destination_addr: 'DESTINATION NUMBER',
			short_message: 'Hello!'
		}, function(pdu) {
			if (pdu.command_status == 0) {
				// Message successfully sent
				console.log(pdu.message_id);
			}
		});
	}
});
```
